### PR TITLE
(fr translation of clear) Nettoyer peut-être ambigu

### DIFF
--- a/app/assets/javascripts/components/locales/fr.jsx
+++ b/app/assets/javascripts/components/locales/fr.jsx
@@ -99,7 +99,7 @@ const fr = {
   "notifications.column_settings.mention": "Mentions :",
   "notifications.column_settings.reblog": "Partages :",
   "notifications.clear": "Nettoyer",
-  "notifications.clear_confirmation": "Voulez-vous vraiment nettoyer toutes vos notifications ?",
+  "notifications.clear_confirmation": "Voulez-vous vraiment supprimer toutes vos notifications ?",
   "notifications.settings": "Paramètres de la colonne",
   "privacy.public.short": "Public",
   "privacy.public.long": "Afficher dans les fils publics",


### PR DESCRIPTION
Un utiliser mal expérimenté pourrait comprendre "retirer les erreurs".
Ici il s'agit d'une suppression pure et simple, pas une épuration/nettoyage.

clear would be translated "remove" instead of "cleaning" Cleaning can be unterstood "keep but clean" 